### PR TITLE
Filter by installed

### DIFF
--- a/VRCMelonAssistant/Pages/Mods.xaml
+++ b/VRCMelonAssistant/Pages/Mods.xaml
@@ -91,7 +91,19 @@
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
 
-                            <GridViewColumn x:Name="InstalledColumn" Header="{DynamicResource Mods:Header:Installed}">
+                            <GridViewColumn x:Name="InstalledColumn">
+                                <GridViewColumn.Header>
+                                    <Button
+                                        Name="InstalledButton"
+                                        Margin="-5"
+                                        Padding="9,-1,9,0"
+                                        Background="#00000000"
+                                        BorderThickness="0"
+                                        Click="InstalledButton_Click"
+                                        Content="{DynamicResource Mods:Header:Installed}"
+                                        FontSize="11"
+                                    />
+                                </GridViewColumn.Header>
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
                                         <TextBlock

--- a/VRCMelonAssistant/Pages/Mods.xaml
+++ b/VRCMelonAssistant/Pages/Mods.xaml
@@ -101,8 +101,9 @@
                                         BorderThickness="0"
                                         Content="{DynamicResource Mods:Header:Installed}"
                                         FontSize="11"
-                                        IsChecked="False" Checked="InstalledButton_Checked" Unchecked="InstalledButton_Unchecked"
-                                    />
+                                        IsChecked="False"
+                                        Checked="InstalledButton_Checked"
+                                        Unchecked="InstalledButton_Unchecked" />
                                 </GridViewColumn.Header>
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>

--- a/VRCMelonAssistant/Pages/Mods.xaml
+++ b/VRCMelonAssistant/Pages/Mods.xaml
@@ -93,15 +93,15 @@
 
                             <GridViewColumn x:Name="InstalledColumn">
                                 <GridViewColumn.Header>
-                                    <Button
+                                    <CheckBox
                                         Name="InstalledButton"
-                                        Margin="-5"
+                                        Margin="7,-5,-5,-5"
                                         Padding="9,-1,9,0"
                                         Background="#00000000"
                                         BorderThickness="0"
-                                        Click="InstalledButton_Click"
                                         Content="{DynamicResource Mods:Header:Installed}"
                                         FontSize="11"
+                                        IsChecked="False" Checked="InstalledButton_Checked" Unchecked="InstalledButton_Unchecked"
                                     />
                                 </GridViewColumn.Header>
                                 <GridViewColumn.CellTemplate>

--- a/VRCMelonAssistant/Pages/Mods.xaml.cs
+++ b/VRCMelonAssistant/Pages/Mods.xaml.cs
@@ -515,7 +515,10 @@ namespace VRCMelonAssistant.Pages
             {
                 Animate(SearchBar, 16, 0, new TimeSpan(0, 0, 0, 0, 300));
                 Animate(SearchText, 16, 0, new TimeSpan(0, 0, 0, 0, 300));
-                ModsListView.Items.Filter = null;
+                if (!FilteredToInstalled)
+                {
+                    ModsListView.Items.Filter = null;
+                }
             }
         }
 
@@ -535,11 +538,16 @@ namespace VRCMelonAssistant.Pages
         private bool SearchFilter(object mod)
         {
             ModListItem item = mod as ModListItem;
-            if (item.ModName.ToLower().Contains(SearchBar.Text.ToLower())) return true;
-            if (item.ModDescription.ToLower().Contains(SearchBar.Text.ToLower())) return true;
-            if (item.ModName.ToLower().Replace(" ", string.Empty).Contains(SearchBar.Text.ToLower().Replace(" ", string.Empty))) return true;
-            if (item.ModDescription.ToLower().Replace(" ", string.Empty).Contains(SearchBar.Text.ToLower().Replace(" ", string.Empty))) return true;
-            return false;
+            if (FilteredToInstalled && !item.IsInstalled) return false;
+            if (SearchBar.Height != 0)
+            {
+                if (item.ModName.ToLower().Contains(SearchBar.Text.ToLower())) return true;
+                if (item.ModDescription.ToLower().Contains(SearchBar.Text.ToLower())) return true;
+                if (item.ModName.ToLower().Replace(" ", string.Empty).Contains(SearchBar.Text.ToLower().Replace(" ", string.Empty))) return true;
+                if (item.ModDescription.ToLower().Replace(" ", string.Empty).Contains(SearchBar.Text.ToLower().Replace(" ", string.Empty))) return true;
+                return false;
+            }
+            return true;
         }
 
         private void InstalledButton_Click(object sender, RoutedEventArgs e)
@@ -547,13 +555,12 @@ namespace VRCMelonAssistant.Pages
             if (!FilteredToInstalled)
             {
                 FilteredToInstalled = true;
-                ModsListView.Items.Filter = new Predicate<object>(InstalledFilter);
             }
             else
             {
-                ModsListView.Items.Filter = null;
                 FilteredToInstalled = false;
             }
+            ModsListView.Items.Filter = new Predicate<object>(SearchFilter);
         }
 
         private bool InstalledFilter(object mod)

--- a/VRCMelonAssistant/Pages/Mods.xaml.cs
+++ b/VRCMelonAssistant/Pages/Mods.xaml.cs
@@ -597,6 +597,5 @@ namespace VRCMelonAssistant.Pages
             if (selectedMod == null) return;
             MainWindow.ShowModInfoWindow(selectedMod.ModInfo);
         }
-
     }
 }

--- a/VRCMelonAssistant/Pages/Mods.xaml.cs
+++ b/VRCMelonAssistant/Pages/Mods.xaml.cs
@@ -522,6 +522,7 @@ namespace VRCMelonAssistant.Pages
                 {
                     ModsListView.Items.Filter = ModsListView.Items.Filter;
                 }
+                // Only null this if both filters (search and installed) are off
                 else
                 {
                     ModsListView.Items.Filter = null;
@@ -545,7 +546,9 @@ namespace VRCMelonAssistant.Pages
         private bool SearchFilter(object mod)
         {
             ModListItem item = mod as ModListItem;
+            // If the installed filter is on, don't search the text of mods that aren't installed
             if (FilteredToInstalled && !item.IsInstalled) return false;
+            // SearchBar.Height does not adjust fast enough to be used here, FilteredBySearch is changed at the same time
             if (FilteredBySearch)
             {
                 if (item.ModName.ToLower().Contains(SearchBar.Text.ToLower())) return true;
@@ -567,13 +570,6 @@ namespace VRCMelonAssistant.Pages
         {
             FilteredToInstalled = false;
             ModsListView.Items.Filter = new Predicate<object>(SearchFilter);
-        }
-
-        private bool InstalledFilter(object mod)
-        {
-            ModListItem item = mod as ModListItem;
-            if (item.IsInstalled) return true;
-            return false;
         }
 
         private void Animate(TextBlock target, double oldHeight, double newHeight, TimeSpan duration)

--- a/VRCMelonAssistant/Pages/Mods.xaml.cs
+++ b/VRCMelonAssistant/Pages/Mods.xaml.cs
@@ -41,6 +41,7 @@ namespace VRCMelonAssistant.Pages
         public bool PendingChanges;
         public bool HaveInstalledMods;
         public bool FilteredToInstalled = false;
+        public bool FilteredBySearch = false;
 
         private readonly SemaphoreSlim _modsLoadSem = new SemaphoreSlim(1, 1);
 
@@ -509,13 +510,19 @@ namespace VRCMelonAssistant.Pages
                 SearchBar.Focus();
                 Animate(SearchBar, 0, 16, new TimeSpan(0, 0, 0, 0, 300));
                 Animate(SearchText, 0, 16, new TimeSpan(0, 0, 0, 0, 300));
+                FilteredBySearch = true;
                 ModsListView.Items.Filter = new Predicate<object>(SearchFilter);
             }
             else
             {
                 Animate(SearchBar, 16, 0, new TimeSpan(0, 0, 0, 0, 300));
                 Animate(SearchText, 16, 0, new TimeSpan(0, 0, 0, 0, 300));
-                if (!FilteredToInstalled)
+                FilteredBySearch = false;
+                if (FilteredToInstalled)
+                {
+                    ModsListView.Items.Filter = ModsListView.Items.Filter;
+                }
+                else
                 {
                     ModsListView.Items.Filter = null;
                 }
@@ -524,7 +531,7 @@ namespace VRCMelonAssistant.Pages
 
         private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
         {
-            ModsListView.Items.Filter = new Predicate<object>(SearchFilter);
+            ModsListView.Items.Filter = ModsListView.Items.Filter;
             if (SearchBar.Text.Length > 0)
             {
                 SearchText.Text = null;
@@ -539,7 +546,7 @@ namespace VRCMelonAssistant.Pages
         {
             ModListItem item = mod as ModListItem;
             if (FilteredToInstalled && !item.IsInstalled) return false;
-            if (SearchBar.Height != 0)
+            if (FilteredBySearch)
             {
                 if (item.ModName.ToLower().Contains(SearchBar.Text.ToLower())) return true;
                 if (item.ModDescription.ToLower().Contains(SearchBar.Text.ToLower())) return true;
@@ -550,16 +557,15 @@ namespace VRCMelonAssistant.Pages
             return true;
         }
 
-        private void InstalledButton_Click(object sender, RoutedEventArgs e)
+        private void InstalledButton_Checked(object sender, RoutedEventArgs e)
         {
-            if (!FilteredToInstalled)
-            {
-                FilteredToInstalled = true;
-            }
-            else
-            {
-                FilteredToInstalled = false;
-            }
+            FilteredToInstalled = true;
+            ModsListView.Items.Filter = new Predicate<object>(SearchFilter);
+        }
+
+        private void InstalledButton_Unchecked(object sender, RoutedEventArgs e)
+        {
+            FilteredToInstalled = false;
             ModsListView.Items.Filter = new Predicate<object>(SearchFilter);
         }
 
@@ -591,5 +597,6 @@ namespace VRCMelonAssistant.Pages
             if (selectedMod == null) return;
             MainWindow.ShowModInfoWindow(selectedMod.ModInfo);
         }
+
     }
 }

--- a/VRCMelonAssistant/Pages/Mods.xaml.cs
+++ b/VRCMelonAssistant/Pages/Mods.xaml.cs
@@ -40,6 +40,7 @@ namespace VRCMelonAssistant.Pages
         public CollectionView view;
         public bool PendingChanges;
         public bool HaveInstalledMods;
+        public bool FilteredToInstalled = false;
 
         private readonly SemaphoreSlim _modsLoadSem = new SemaphoreSlim(1, 1);
 
@@ -538,6 +539,27 @@ namespace VRCMelonAssistant.Pages
             if (item.ModDescription.ToLower().Contains(SearchBar.Text.ToLower())) return true;
             if (item.ModName.ToLower().Replace(" ", string.Empty).Contains(SearchBar.Text.ToLower().Replace(" ", string.Empty))) return true;
             if (item.ModDescription.ToLower().Replace(" ", string.Empty).Contains(SearchBar.Text.ToLower().Replace(" ", string.Empty))) return true;
+            return false;
+        }
+
+        private void InstalledButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!FilteredToInstalled)
+            {
+                FilteredToInstalled = true;
+                ModsListView.Items.Filter = new Predicate<object>(InstalledFilter);
+            }
+            else
+            {
+                ModsListView.Items.Filter = null;
+                FilteredToInstalled = false;
+            }
+        }
+
+        private bool InstalledFilter(object mod)
+        {
+            ModListItem item = mod as ModListItem;
+            if (item.IsInstalled) return true;
             return false;
         }
 


### PR DESCRIPTION
I was annoyed that I wasn't able to filter down to what mods I had installed, this change adds that functionality.

**Changes**:
Pages/Mods.xaml:
-
- Installed header was changed to a checkbox, to try to stay consistent, I copied the values from the search header, although the margin was changed to allow the checkbox part to fit.
- I didn't spend long on the front end, I just wanted the UI to show that there was an option for this and to show the state of it.


Pages/Mods.xaml.cs:
-
- This uses ModsListView.Items.Filter, which is the same thing the text search uses, a lot of the code in this change is built around supporting the ability to use both filtering options at the same time.
- FilteredToInstalled and FilteredBySearch are both simple state tracking bools, they're true whenever you're using one of the filters.
- While SearchBar.Height == 0 was used in one spot, I tried to use the same logic again when the text search is called, but it doesn't seem to update fast enough and my breakpoints were never hit, which is the reason for FilteredBySearch now exists.

